### PR TITLE
ユーザの削除ができないバグの修正

### DIFF
--- a/server.js
+++ b/server.js
@@ -46,11 +46,13 @@ app.post("/manage", (req, res) => {
     if (req.body.type === 'register') {
         if (persons.find((e) => e.name === req.body.name) == null) {
             let person = {
-                id: escape(req.body.name),
+                id: getNewId(),
                 name: req.body.name,
                 theme: null,
             };
             persons.push(person);
+        } else {
+            res.send("同名のユーザが存在します。");
         }
     }else if(req.body.type === 'allocate'){
         const themes = JSON.parse(fs.readFileSync('./themes.json', 'utf-8'));
@@ -80,7 +82,7 @@ app.post("/manage", (req, res) => {
 
 app.delete("/user/:id", (req, res) => {
     // 該当IDのデータを検索
-    let person = persons.find((e) => e.id === req.params.id);
+    let person = persons.find((e) => e.id === Number(req.params.id));
     if(!person){
         res.send("該当IDのユーザが見つかりませんでした。");
     }
@@ -101,4 +103,14 @@ function shuffle(arr){
         arr[r] = tmp;
     }
     return arr;
+}
+
+function getNewId() {
+    for(let i = 1; i <= persons.length; i++) {
+        const person = persons.find((e) => e.id === i);
+        if(!person){
+            return i;
+        }
+    }
+    return persons.length + 1;
 }


### PR DESCRIPTION
- URIにUnicode形式でエンコードした文字列が含まれると、APIを受け取ったときに勝手にエンコードしようとするクソ仕様がある模様
- それを回避するために、やっぱりIDは数値で、ユーザ作成時に重複がないように取得するよう修正
- IDは昇順で、一番若い数字を取得するようになっている