### PR TITLE
存在するユーザ名を追加した際に、二重でres.sendが実行される事象を回避

### DIFF
--- a/server.js
+++ b/server.js
@@ -57,6 +57,8 @@ app.post("/manage", (req, res) => {
                 theme: null,
             };
             persons.push(person);
+
+            res.redirect('/manage');
         } else {
             res.send("同名のユーザが存在します。");
         }
@@ -82,8 +84,9 @@ app.post("/manage", (req, res) => {
         }
 
         persons = shuffle(persons);
+
+        res.redirect('/manage');
     }
-    res.redirect('/manage');
 });
 
 app.delete("/user/:id", (req, res) => {


### PR DESCRIPTION
二重でres.sendまたはres.redirectを実行した際に生じる下記エラーを回避。
・Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client